### PR TITLE
Feature: Extended Weather Data

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -67,8 +67,7 @@ $('#mapbox_form').submit( function(e) {
             $('#campsite-' + i).append('<li>(no image available)</li>');
           };
           // Look up the weather conditions at each site
-          // Now uses the lat and lon data for #campsite-i
-          fetch("https://api.openweathermap.org/data/2.5/forecast?lat=" + $('#campsite-'+i).data('lat') + "&lon=" + $('#campsite-'+i).data('lon') + "&appid=1168898d2e6677ed97caa56280826004&units=imperial")
+          fetch("https://api.openweathermap.org/data/2.5/forecast?lat=" + filtered_nps[i].latitude + "&lon=" + filtered_nps[i].longitude + "&appid=1168898d2e6677ed97caa56280826004&units=imperial")
           .then(function(response) {return response.json();})
           .then(function(data) {
             $('#campsite-'+i+' .weather-data').append('<b>Weather:</b><ul><li> Temp at Campsite: ' + data.list[0].main.temp + '°F </li>' +
@@ -91,7 +90,17 @@ $(document).on('click', '.forecast-button', function () {
   //Looks to its grandparent (#campsite-i) for its lat lon data
   console.log('ID of Grandparent: '+$(this).parents(':eq(1)').attr('id'));
   console.log('Lat Lon of chosen campsite: '+$(this).parents(':eq(1)').data('lat')+" "+$(this).parents(':eq(1)').data('lon'));
+  forecast_call($(this).parents(':eq(1)').data('lat'), $(this).parents(':eq(1)').data('lon'))
 });
+
+function forecast_call (lat, lon) {
+  console.log("Lat Lon being passed into forecast_call function: " + lat + " " +lon);
+  fetch("https://api.openweathermap.org/data/2.5/forecast?lat=" + lat + "&lon=" + lon + "&appid=1168898d2e6677ed97caa56280826004&units=imperial")
+  .then(function(response) {return response.json();})
+  .then(function(data) {
+    console.log(data);
+  });
+}
 
 function init_map () {
   // WORK IN PROGRESS

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -46,8 +46,14 @@ $('#mapbox_form').submit( function(e) {
       if (filtered_nps.length > 0) {
         $('#results_list').append('<ol></ol>');
         for (let i=0;i<filtered_nps.length;i++) {
+
           // Add an ordered list item for each campsite.
           $('#results_list ol').append('<li><ul id="campsite-' + i + '"></ul></li>');
+          //Stores the LAT LON data for forecast lookup later
+          $('#campsite-'+i).data('lat', filtered_nps[i].latitude);
+          $('#campsite-'+i).data('lon', filtered_nps[i].longitude);
+          console.log('Campsite LAT LON Data: '+$('#campsite-'+i).data('lat')+" "+$('#campsite-'+i).data('lon'));
+
           // Populate the ordered list with general info about the campsite.
           $('#campsite-'+i).append('<li><b>' + filtered_nps[i].name + '</b></li>');
           $('#campsite-'+i).append('<li><b>Distance: </b>' + get_distance_miles(
@@ -69,6 +75,14 @@ $('#mapbox_form').submit( function(e) {
           .then(function(data) {
             $('#campsite-'+i+' .weather-data').append('<b>Weather:</b><ul><li> Temp at Campsite: ' + data.list[0].main.temp + '°F </li>' +
             '<li> Current Weather at Campsite: ' + data.list[0].weather[0].description + '</li></ul>');
+
+            //Adds lat lon data to the weather section
+            //$('#campsite-'+i).data('lat', filtered_nps[i].latitude);
+            // console.log('Check if data is stored '+$('#campsite-'+i).dataset.test);
+
+            //Add button to view a 5-Day forecast for each campsite
+            $('#campsite-'+i+' .weather-data').append('<button class="forecast-button" id="button-for-campsite-'+i+'">View Forecast</button>');
+    
           }); 
         }
       } else {
@@ -76,6 +90,11 @@ $('#mapbox_form').submit( function(e) {
       }
     }   
   });
+});
+
+//VIEW FORECAST BUTTON
+$(document).on('click', '.forecast-button', function () {
+  console.log('You pressed ' + this.id);
 });
 
 function init_map () {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -46,14 +46,12 @@ $('#mapbox_form').submit( function(e) {
       if (filtered_nps.length > 0) {
         $('#results_list').append('<ol></ol>');
         for (let i=0;i<filtered_nps.length;i++) {
-
           // Add an ordered list item for each campsite.
           $('#results_list ol').append('<li><ul id="campsite-' + i + '"></ul></li>');
           //Stores the LAT LON data for forecast lookup later
           $('#campsite-'+i).data('lat', filtered_nps[i].latitude);
           $('#campsite-'+i).data('lon', filtered_nps[i].longitude);
-          console.log('Campsite LAT LON Data: '+$('#campsite-'+i).data('lat')+" "+$('#campsite-'+i).data('lon'));
-
+          console.log('Campsite'+i+ 'LAT LON Data: '+$('#campsite-'+i).data('lat')+" "+$('#campsite-'+i).data('lon'));
           // Populate the ordered list with general info about the campsite.
           $('#campsite-'+i).append('<li><b>' + filtered_nps[i].name + '</b></li>');
           $('#campsite-'+i).append('<li><b>Distance: </b>' + get_distance_miles(
@@ -68,18 +66,13 @@ $('#mapbox_form').submit( function(e) {
           } else {
             $('#campsite-' + i).append('<li>(no image available)</li>');
           };
-
           // Look up the weather conditions at each site
-          fetch("https://api.openweathermap.org/data/2.5/forecast?lat=" + filtered_nps[i].latitude + "&lon=" + filtered_nps[i].longitude + "&appid=1168898d2e6677ed97caa56280826004&units=imperial")
+          // Now uses the lat and lon data for #campsite-i
+          fetch("https://api.openweathermap.org/data/2.5/forecast?lat=" + $('#campsite-'+i).data('lat') + "&lon=" + $('#campsite-'+i).data('lon') + "&appid=1168898d2e6677ed97caa56280826004&units=imperial")
           .then(function(response) {return response.json();})
           .then(function(data) {
             $('#campsite-'+i+' .weather-data').append('<b>Weather:</b><ul><li> Temp at Campsite: ' + data.list[0].main.temp + '°F </li>' +
             '<li> Current Weather at Campsite: ' + data.list[0].weather[0].description + '</li></ul>');
-
-            //Adds lat lon data to the weather section
-            //$('#campsite-'+i).data('lat', filtered_nps[i].latitude);
-            // console.log('Check if data is stored '+$('#campsite-'+i).dataset.test);
-
             //Add button to view a 5-Day forecast for each campsite
             $('#campsite-'+i+' .weather-data').append('<button class="forecast-button" id="button-for-campsite-'+i+'">View Forecast</button>');
     
@@ -95,6 +88,9 @@ $('#mapbox_form').submit( function(e) {
 //VIEW FORECAST BUTTON
 $(document).on('click', '.forecast-button', function () {
   console.log('You pressed ' + this.id);
+  //Looks to its grandparent (#campsite-i) for its lat lon data
+  console.log('ID of Grandparent: '+$(this).parents(':eq(1)').attr('id'));
+  console.log('Lat Lon of chosen campsite: '+$(this).parents(':eq(1)').data('lat')+" "+$(this).parents(':eq(1)').data('lon'));
 });
 
 function init_map () {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -51,7 +51,7 @@ $('#mapbox_form').submit( function(e) {
           //Stores the LAT LON data for forecast lookup later
           $('#campsite-'+i).data('lat', filtered_nps[i].latitude);
           $('#campsite-'+i).data('lon', filtered_nps[i].longitude);
-          console.log('Campsite'+i+ 'LAT LON Data: '+$('#campsite-'+i).data('lat')+" "+$('#campsite-'+i).data('lon'));
+          //console.log('Campsite'+i+ 'LAT LON Data: '+$('#campsite-'+i).data('lat')+" "+$('#campsite-'+i).data('lon'));
           // Populate the ordered list with general info about the campsite.
           $('#campsite-'+i).append('<li><b>' + filtered_nps[i].name + '</b></li>');
           $('#campsite-'+i).append('<li><b>Distance: </b>' + get_distance_miles(
@@ -74,7 +74,6 @@ $('#mapbox_form').submit( function(e) {
             '<li> Current Weather at Campsite: ' + data.list[0].weather[0].description + '</li></ul>');
             //Add button to view a 5-Day forecast for each campsite
             $('#campsite-'+i+' .weather-data').append('<button class="forecast-button" id="button-for-campsite-'+i+'">View Forecast</button>');
-    
           }); 
         }
       } else {
@@ -86,10 +85,6 @@ $('#mapbox_form').submit( function(e) {
 
 //VIEW FORECAST BUTTON
 $(document).on('click', '.forecast-button', function () {
-  console.log('You pressed ' + this.id);
-  //Looks to its grandparent (#campsite-i) for its lat lon data
-  console.log('ID of Grandparent: '+$(this).parents(':eq(1)').attr('id'));
-  console.log('Lat Lon of chosen campsite: '+$(this).parents(':eq(1)').data('lat')+" "+$(this).parents(':eq(1)').data('lon'));
   forecast_call($(this).parents(':eq(1)').data('lat'), $(this).parents(':eq(1)').data('lon'))
 });
 
@@ -98,7 +93,26 @@ function forecast_call (lat, lon) {
   fetch("https://api.openweathermap.org/data/2.5/forecast?lat=" + lat + "&lon=" + lon + "&appid=1168898d2e6677ed97caa56280826004&units=imperial")
   .then(function(response) {return response.json();})
   .then(function(data) {
-    console.log(data);
+
+    let indexDay = moment.unix(data.list[0].dt).format("MM/DD/YYYY");
+    let indexRain = false;
+
+    for (let i = 0; i < data.list.length; i++) {
+      if (data.list[i].weather[0].description.includes('rain')) {
+        //Check if the description for that 3 hour block includes rain at all
+        indexRain = true;
+      };
+      if (indexDay != moment.unix(data.list[i].dt).format("MM/DD/YYYY")) {
+        //That means we're looking at a new day's weather
+        if (indexRain) {
+          console.log("It will rain at this campsite on "+indexDay+" !");
+        } else {
+          console.log("It will not rain at this campsite on "+indexDay+" !");
+        };
+      indexRain = false;
+      indexDay = moment.unix(data.list[i].dt).format("MM/DD/YYYY")
+      };
+    }
   });
 }
 

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <script src="./assets/openlayers/dist/ol.js"></script>
   <link rel="stylesheet" href="./assets/openlayers/ol.css">
   <script src="https://code.jquery.com/jquery-3.6.1.min.js" integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ=" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.27.0/moment.min.js"></script>
   <title>API Test</title>
 </head>
 


### PR DESCRIPTION
Added "lat" and "lon" data attributes to the "campsite-x" id's, which means that each search result stores where it is even after the API calls have been made. Handy for possibly helping with the map integration.
These lat and lon data attributes are then looked at when a new "View Forecast" button is pressed, which then calls a function to look up weather data for just that campsite.
Not much is actually done with the weather data at the moment, but there is a small for loop that outputs to the console if any given day in the forecast includes rain.